### PR TITLE
Added ConfigProvider making Config more extendable

### DIFF
--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -114,7 +114,7 @@ def test_read(config_dict, expect_error):
     ('3', dict(cast=int), 3),
     ('a', dict(cast=int), ValueError),
 ])
-def test_get_key(prop_val, args, expected_value_or_error):
+def test_key_getter(prop_val, args, expected_value_or_error):
     class SampleConfig(Config):
         prop = key('s', 'prop1', **args)
 
@@ -131,6 +131,16 @@ def test_get_key(prop_val, args, expected_value_or_error):
     else:
         v = config.prop
         assert expected_value_or_error == v
+
+
+def test_get_key():
+    class SampleConfig(Config):
+        prop = key('s', 'prop1')
+
+    config = SampleConfig()
+    config.add_source(DictConfigSource({'s': {'PROP1': 'propval'}}))
+    v = config.get_key('s', 'prop1')
+    assert v == 'propval'
 
 
 def test_caching():

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -1,7 +1,7 @@
 import inspect
 import pytest
 from unittest.mock import MagicMock
-from typedconfig.config import Config, key, section, group_key
+from typedconfig.config import Config, key, section, group_key, ConfigProvider
 from typedconfig.source import DictConfigSource, ConfigSource
 
 
@@ -298,3 +298,17 @@ def test_cast_with_default():
     s.add_source(DictConfigSource({}))
     assert s.nullable_key is None
     assert s.bool_key is False
+
+
+def test_provider_property_read():
+    provider = ConfigProvider()
+    config = ParentConfig(provider=provider)
+    p = config.provider
+    # Check same object is returned
+    assert p is provider
+
+
+def test_provider_property_is_readonly():
+    config = ParentConfig()
+    with pytest.raises(Exception):
+        config.provider = ConfigProvider()

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -312,3 +312,23 @@ def test_provider_property_is_readonly():
     config = ParentConfig()
     with pytest.raises(Exception):
         config.provider = ConfigProvider()
+
+
+def test_construct_config_without_provider():
+    sources = [DictConfigSource({})]
+    config = ParentConfig(sources=sources)
+    assert isinstance(config.provider, ConfigProvider)
+    assert config.provider.config_sources == sources
+
+
+def test_construct_config_bad_provider_type():
+    with pytest.raises(TypeError):
+        config = ParentConfig(provider=3)
+
+
+def test_construct_config_with_provider():
+    sources = [DictConfigSource({})]
+    provider = ConfigProvider(sources)
+    config = ParentConfig(sources=sources, provider=provider)
+    assert config.provider is provider
+    assert config.config_sources == sources

--- a/typedconfig/config.py
+++ b/typedconfig/config.py
@@ -155,6 +155,8 @@ class Config:
                  provider: Optional[ConfigProvider]=None):
         if provider is None:
             provider = ConfigProvider(sources=sources)
+        elif not isinstance(provider, ConfigProvider):
+            raise TypeError("provider must be a ConfigProvider object")
         self._section_name = section_name
         self._provider: ConfigProvider = provider
 

--- a/typedconfig/config.py
+++ b/typedconfig/config.py
@@ -151,10 +151,7 @@ class Config:
     def __init__(self, section_name=None, sources: List[ConfigSource]=None,
                  provider: Optional[ConfigProvider]=None):
         self._section_name = section_name
-        self._provider: ConfigProvider = provider or ConfigProvider()
-        if sources is not None:
-            for s in sources:
-                self._provider.add_source(s)
+        self._provider: ConfigProvider = provider or ConfigProvider(sources=sources)
 
     @property
     def config_sources(self) -> List[ConfigSource]:

--- a/typedconfig/config.py
+++ b/typedconfig/config.py
@@ -153,8 +153,10 @@ class Config:
 
     def __init__(self, section_name=None, sources: List[ConfigSource]=None,
                  provider: Optional[ConfigProvider]=None):
+        if provider is None:
+            provider = ConfigProvider(sources=sources)
         self._section_name = section_name
-        self._provider: ConfigProvider = provider or ConfigProvider(sources=sources)
+        self._provider: ConfigProvider = provider
 
     @property
     def config_sources(self) -> List[ConfigSource]:

--- a/typedconfig/config.py
+++ b/typedconfig/config.py
@@ -157,6 +157,10 @@ class Config:
     def config_sources(self) -> List[ConfigSource]:
         return self._provider.config_sources
 
+    @property
+    def provider(self) -> ConfigProvider:
+        return self._provider
+
     def get_registered_properties(self) -> List[str]:
         """
         Gets a list of all properties which have been defined using the key function

--- a/typedconfig/provider.py
+++ b/typedconfig/provider.py
@@ -7,9 +7,12 @@ class ConfigProvider:
     Configuration provider keeping the cache and sources that can be shared
     across the configuration objects
     """
-    def __init__(self):
+    def __init__(self, sources: List[ConfigSource]=None):
         self._cache: Dict[str, Dict[str, str]] = {}
         self._config_sources: List[ConfigSource] = []
+        if sources is not None:
+            for s in sources:
+                self.add_source(s)
 
     def add_to_cache(self, section_name: str, key_name: str, value) -> None:
         if section_name not in self._cache:

--- a/typedconfig/provider.py
+++ b/typedconfig/provider.py
@@ -1,0 +1,45 @@
+from typing import List, Optional, Dict
+from typedconfig.source import ConfigSource
+
+
+class ConfigProvider:
+    """
+    Configuration provider keeping the cache and sources that can be shared
+    across the configuration objects
+    """
+    def __init__(self):
+        self._cache: Dict[str, Dict[str, str]] = {}
+        self._config_sources: List[ConfigSource] = []
+
+    def add_to_cache(self, section_name: str, key_name: str, value) -> None:
+        if section_name not in self._cache:
+            self._cache[section_name] = {}
+        self._cache[section_name][key_name] = value
+
+    def get_from_cache(self, section_name: str, key_name: str):
+        if section_name not in self._cache:
+            return None
+        return self._cache[section_name].get(key_name, None)
+
+    def clear_cache(self) -> None:
+        self._cache.clear()
+
+    @property
+    def config_sources(self) -> List[ConfigSource]:
+        return self._config_sources
+
+    def get_key(self, section_name: str, key_name: str) -> Optional[str]:
+        value = None
+
+        # Go through the config sources until we find one which supplies the requested value
+        for source in self._config_sources:
+            value = source.get_config_value(section_name, key_name)
+            if value is not None:
+                break
+
+        return value
+
+    def add_source(self, source: ConfigSource):
+        if not isinstance(source, ConfigSource):
+            raise TypeError("Sources must be subclasses of ConfigSource")
+        self._config_sources.append(source)


### PR DESCRIPTION
Hi! 

First of all, I really appreciate all the work you've done with the typed-config library. 

I'm trying to find a good design pattern for configuration management in Python apps. In application we develop, we need to deal with different environments (perfect use-case for various `ConfigSource`) and because configuration constantly grows along with development of new features, we need some schemas/typings. It seems that your library fulfills almost all of my needs :)

The application we develop comes with a simple plugin system. Plugins need to be configured as well, so there must be a way to declare additional sections used by a plugin along with main configuration.

If I correctly understand the code: `Config` objects are bound together by common `_cache` and `_sources` objects. In this PR I've moved them to the separate object called `ConfigProvider`, shared across the instances. The provider makes the interface more flexible and it can be passed as an `__init__` argument and is exposed by `Config` instances.

Exposed `ConfigProvider` allows us to inherit from `Config` classes/objects, so it can be used by plugins to provide the extended view of the main configuration.

e.g. [`app/config.py`](https://github.com/psrok1/typed-config-pluggable-example/blob/master/app/config.py):
```python
from typedconfig import Config, key, group_key, section
from typedconfig.source import IniFileConfigSource, EnvironmentConfigSource


@section('database')
class DatabaseConfig(Config):
    """
    Database configuration
    """
    host = key(cast=str)
    port = key(cast=int)
    timeout = key(cast=float)


class ApplicationConfig(Config):
    """
    Main configuration object
    """
    database = group_key(DatabaseConfig)


config = ApplicationConfig(sources=[
    EnvironmentConfigSource(),
    IniFileConfigSource("config.ini")
])
```

can be extended by [`plugin/friendly_plugin.py`](https://github.com/psrok1/typed-config-pluggable-example/blob/master/plugins/friendly_plugin.py) by binding `ConfigProvider` exposed by the main configuration object with a plugin's own class:

```python
from typedconfig import Config, section, group_key, key

from app.config import ApplicationConfig, config


@section("friendly_plugin")
class WhatToSayConfig(Config):
    """
    Additional section with plugin-specific configuration
    """
    what_to_say = key(cast=str)


class FriendlyPluginConfig(ApplicationConfig):
    """
    Main configuration object extended by plugin-specific sections
    """
    friendly_plugin = group_key(WhatToSayConfig)


# Use common provider with app configuration
config = FriendlyPluginConfig(provider=config.provider)


def execute():
    # Usage of plugin-specific values
    print(f"Friendly Plugin says {config.friendly_plugin.what_to_say}")
    # Usage of application-wide values
    print(f"Let's pretend that we're connecting to {config.database.host}:{config.database.port}...")
```

Usage example can be also find here: https://github.com/psrok1/typed-config-pluggable-example

What do you think about it? If you want me to provide some feature-specific tests or an additional section in README, just let me know!

I propose that as a more clean alternative to "dynamic section injection" approach suggested in #1.
