### PR TITLE
Fix: don't cast default value if it's set to None

### DIFF
--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -285,3 +285,16 @@ def test_multiple_group_keys_with_section_decorators():
 
     assert 'v1' == p.c1.k1
     assert 'v2' == p.c2.k2
+
+
+def test_cast_with_default():
+
+    @section('s')
+    class SampleConfig(Config):
+        nullable_key = key(cast=str, required=False, default=None)
+        bool_key = key(cast=bool, required=False, default=False)
+
+    s = SampleConfig()
+    s.add_source(DictConfigSource({}))
+    assert s.nullable_key is None
+    assert s.bool_key is False

--- a/typedconfig/config.py
+++ b/typedconfig/config.py
@@ -89,7 +89,7 @@ def key(section_name: str=None,
                 value = default
 
         # If a casting function has been specified then cast to the required data type
-        if cast is not None:
+        if value is not None and cast is not None:
             value = cast(value)
 
         # Cache this for next time if still not none


### PR DESCRIPTION
For code specified below:
```python
@section('s')
class SampleConfig(Config):
    nullable_key = key(cast=str, required=False, default=None)

s = SampleConfig()
s.add_source(DictConfigSource({}))
print(s.nullable_key, type(s.nullable_key))
```
Expected output
```
None <class 'NoneType'>
```
Actual output:
```
None <class 'str'>
```

This PR provides fix for that bug by checking whether value is None before casting.