### PR TITLE
Adding enum_type as an option arg to the key() function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,3 +64,6 @@ Enable CI testing on Python 3.10 and 3.11. Use `sys.version_info` to help with i
 
 ### v1.3.0
 Drop running tests on Python 3.6 since it is end of life.
+
+### v1.3.1
+As part of a solution for issue #12, add enum_type as a parameter to key to make it easier to parse out enum names from configs

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -1,5 +1,6 @@
 import inspect
 import pytest
+from enum import Enum
 from unittest.mock import MagicMock
 from typedconfig.config import Config, key, section, group_key, ConfigProvider
 from typedconfig.source import DictConfigSource, ConfigSource
@@ -17,6 +18,12 @@ class ChildConfig(Config):
 class ParentConfig(Config):
     prop1 = key(section_name='parent', key_name='PROP1')
     child_config = group_key(ChildConfig)
+
+
+class ExampleEnum(Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
 
 
 def test_subclass_config():
@@ -139,6 +146,8 @@ def test_read(config_dict, expect_error):
     ('3', dict(required=False, default=3), '3'),
     (None, dict(required=False, default=3, cast=int), 3),
     ('3', dict(required=False, default=3, cast=int), 3),
+    ("BLUE", dict(enum_type=ExampleEnum), ExampleEnum.BLUE),
+    ("PURPLE", dict(enum_type=ExampleEnum), KeyError),
 ])
 def test_key_getter(prop_val, args, expected_value_or_error):
     class SampleConfig(Config):
@@ -567,3 +576,9 @@ def test_config_repr():
 
     config = SampleConfig()
     assert repr(config) == "SampleConfig(b='B', child=SampleChildConfig(a='A'))"
+
+
+def test_bad_enum_type():
+    with pytest.raises(KeyError):
+        class SampleConfig(Config):
+            bad_enum_cast = key(cast=int, enum_type=ExampleEnum)

--- a/typedconfig/__version__.py
+++ b/typedconfig/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 3, 0)
+VERSION = (1, 3, 1)
 
 __version__ = '.'.join(map(str, VERSION))


### PR DESCRIPTION
This can be used instead of the usual cast argument for converting input strings to Enum types.

If you have an Enum called MyEnumType you can call
key(enum_type = MyEnumType)
And get a cast function that will turn a string into a member of MyEnumType

If you try to set both cast and enum_type, it will throw a KeyError

If the config reads a string that is not in MyEnumType._member_names, it will throw a KeyError

The pytests have been updated to cover all of this. 

Note:
* There are a few way I could imagine approaching this. This seems the cleanest and most intuitive to me, though I am certainly open to alternate suggestions. 
* I have not updated the README.md file with this functionality. If this is deemed to be a useful addition, I can do that either as part of this PR or as a separate one. 