### PR TITLE
This creates a new submodule called casts to serve as a library of helper cast functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,3 +64,6 @@ Enable CI testing on Python 3.10 and 3.11. Use `sys.version_info` to help with i
 
 ### v1.3.0
 Drop running tests on Python 3.6 since it is end of life.
+
+### v1.3.1
+As part of a solution for issue #12, add enum_type as a parameter to key to make it easier to parse out enum names from configs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,4 +66,4 @@ Enable CI testing on Python 3.10 and 3.11. Use `sys.version_info` to help with i
 Drop running tests on Python 3.6 since it is end of life.
 
 ### v1.3.1
-As part of a solution for issue #12, add enum_type as a parameter to key to make it easier to parse out enum names from configs
+As part of a solution for issue #12, add cast submodule with enum_cast helper function

--- a/README.md
+++ b/README.md
@@ -471,6 +471,33 @@ These are listed here:
 | --- | --- | --- |
 | [typed-config-aws-sources](https://pypi.org/project/typed-config-aws-sources) | `typedconfig_awssource` | Config sources using `boto3` to get config e.g. from S3 or DynamoDB
 
+
+## Cast function library
+The `typedconfig.casts` module contains helper functions that implement common casting operations. These would generally be passed to the `cast` parameter of the `key()` function
+
+### Casting to an `Enum` type with `enum_cast`
+the `enum_cast` function converts a string input from a source to an member of an `Enum` type. 
+
+For example:
+```python
+from enum import Enum
+from typedconfig.casts import enum_cast
+from typedconfig import Config, key
+...
+class ColorEnum(Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+...
+
+class MyConfig(Config):
+    color = key(cast=enum_cast(ColorEnum))
+```
+
+In this example, if the `ConfigSource` reads the string `"RED"`, the value of `color` will be set to `ColorEnum.RED`
+
+Note that the `enum_cast` function is designed to read the *name* of an enum member, not its value (`1`, `2` or `3` in the example above)
+
 ## Contributing
 Ideas for new features and pull requests are welcome. PRs must come with tests included. This was developed using Python 3.7 but Travis tests run with all versions 3.6-3.9 too.
 

--- a/test/test_casts.py
+++ b/test/test_casts.py
@@ -1,0 +1,19 @@
+import pytest
+
+from enum import Enum
+from typedconfig.casts import enum_cast
+
+
+class ExampleEnum(Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+
+def test_enum_cast():
+    getter = enum_cast(ExampleEnum)
+
+    assert getter("BLUE") == ExampleEnum.BLUE
+
+    with pytest.raises(KeyError):
+        getter("PURPLE")

--- a/test/test_casts.py
+++ b/test/test_casts.py
@@ -14,8 +14,8 @@ def test_valid_enum_cast():
     getter = enum_cast(ExampleEnum)
     assert getter("BLUE") == ExampleEnum.BLUE
 
-   
-def test_invalid_enum_cast():   
+
+def test_invalid_enum_cast():
     getter = enum_cast(ExampleEnum)
     with pytest.raises(KeyError):
         getter("PURPLE")

--- a/test/test_casts.py
+++ b/test/test_casts.py
@@ -10,10 +10,12 @@ class ExampleEnum(Enum):
     BLUE = 3
 
 
-def test_enum_cast():
+def test_valid_enum_cast():
     getter = enum_cast(ExampleEnum)
-
     assert getter("BLUE") == ExampleEnum.BLUE
 
+   
+def test_invalid_enum_cast():   
+    getter = enum_cast(ExampleEnum)
     with pytest.raises(KeyError):
         getter("PURPLE")

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -1,5 +1,7 @@
 import inspect
 import pytest
+from enum import Enum
+from typedconfig.casts import enum_cast
 from unittest.mock import MagicMock
 from typedconfig.config import Config, key, section, group_key, ConfigProvider
 from typedconfig.source import DictConfigSource, ConfigSource
@@ -17,6 +19,12 @@ class ChildConfig(Config):
 class ParentConfig(Config):
     prop1 = key(section_name="parent", key_name="PROP1")
     child_config = group_key(ChildConfig)
+
+
+class ExampleEnum(Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
 
 
 def test_subclass_config():
@@ -570,3 +578,4 @@ def test_config_repr():
 
     config = SampleConfig()
     assert repr(config) == "SampleConfig(b='B', child=SampleChildConfig(a='A'))"
+

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -1,7 +1,5 @@
 import inspect
 import pytest
-from enum import Enum
-from typedconfig.casts import enum_cast
 from unittest.mock import MagicMock
 from typedconfig.config import Config, key, section, group_key, ConfigProvider
 from typedconfig.source import DictConfigSource, ConfigSource
@@ -19,12 +17,6 @@ class ChildConfig(Config):
 class ParentConfig(Config):
     prop1 = key(section_name="parent", key_name="PROP1")
     child_config = group_key(ChildConfig)
-
-
-class ExampleEnum(Enum):
-    RED = 1
-    GREEN = 2
-    BLUE = 3
 
 
 def test_subclass_config():
@@ -578,4 +570,3 @@ def test_config_repr():
 
     config = SampleConfig()
     assert repr(config) == "SampleConfig(b='B', child=SampleChildConfig(a='A'))"
-

--- a/typedconfig/__version__.py
+++ b/typedconfig/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 3, 0)
+VERSION = (1, 3, 1)
 
 __version__ = ".".join(map(str, VERSION))

--- a/typedconfig/casts.py
+++ b/typedconfig/casts.py
@@ -1,12 +1,14 @@
 from enum import Enum, EnumMeta
 from typing import TypeVar, Callable, Type
 
-TEnum = TypeVar('TEnum', bound="Enum")
+TEnum = TypeVar("TEnum", bound="Enum")
 
-def enum_cast(enum_type: Type[TEnum]) -> Callable[[str], Enum]:
-    def getter(name: str)->Enum:
+
+def enum_cast(enum_type: Type[TEnum]) -> Callable[[str], TEnum]:
+    def getter(name: str) -> TEnum:
         try:
-             return  enum_type[name]
+            return enum_type[name]
         except KeyError:
             raise KeyError(f"{name} is not a member of {enum_type}")
+
     return getter

--- a/typedconfig/casts.py
+++ b/typedconfig/casts.py
@@ -1,4 +1,4 @@
-from enum import Enum, EnumMeta
+from enum import Enum
 from typing import TypeVar, Callable, Type
 
 TEnum = TypeVar("TEnum", bound="Enum")

--- a/typedconfig/casts.py
+++ b/typedconfig/casts.py
@@ -1,7 +1,7 @@
-from enum import Enum, EnumType
+from enum import Enum, EnumMeta
 from typing import  Callable
 
-def enum_cast(enum_type: EnumType)->Callable[[str], Enum]:
+def enum_cast(enum_type: EnumMeta)->Callable[[str], Enum]:
     def getter(name: str)->Enum:
         if name not in enum_type._member_names_:
             raise KeyError(f"{name} is not a member of {enum_type}")

--- a/typedconfig/casts.py
+++ b/typedconfig/casts.py
@@ -1,0 +1,11 @@
+from enum import Enum, EnumType
+from typing import  Callable
+
+def enum_cast(enum_type: EnumType)->Callable[[str], Enum]:
+    def getter(name: str)->Enum:
+        if name not in enum_type._member_names_:
+            raise KeyError(f"{name} is not a member of {enum_type}")
+        cast_value = enum_type._member_map_[name]
+        return cast_value
+
+    return getter

--- a/typedconfig/casts.py
+++ b/typedconfig/casts.py
@@ -1,11 +1,12 @@
 from enum import Enum, EnumMeta
-from typing import  Callable
+from typing import TypeVar, Callable, Type
 
-def enum_cast(enum_type: EnumMeta)->Callable[[str], Enum]:
+TEnum = TypeVar('TEnum', bound="Enum")
+
+def enum_cast(enum_type: Type[TEnum]) -> Callable[[str], Enum]:
     def getter(name: str)->Enum:
-        if name not in enum_type._member_names_:
+        try:
+             return  enum_type[name]
+        except KeyError:
             raise KeyError(f"{name} is not a member of {enum_type}")
-        cast_value = enum_type._member_map_[name]
-        return cast_value
-
     return getter


### PR DESCRIPTION
These would ostensibly be used in the key() functions cast parameter

For now the cast submodule contains 1 function: enum_cast which converts a string to a member of a passed enum

If you have an Enum called MyEnumType you can call
    key(cast = enum_cast(MyEnumType))
And get a cast function that will turn a string into a member of MyEnumType

If the config reads a string that is not in MyEnumType._member_names, it will throw a KeyError