### PR TITLE
Adding tuple_cast to the casts submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,3 +67,6 @@ Drop running tests on Python 3.6 since it is end of life.
 
 ### v1.3.1
 As part of a solution for issue #12, add cast submodule with enum_cast helper function
+
+### v1.3.2
+Add list_cast to the the cast submodule and document it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,4 +69,4 @@ Drop running tests on Python 3.6 since it is end of life.
 As part of a solution for issue #12, add cast submodule with enum_cast helper function
 
 ### v1.3.2
-Add list_cast to the the cast submodule and document it
+Add tuple_cast to the the cast submodule and document it

--- a/README.md
+++ b/README.md
@@ -498,8 +498,8 @@ In this example, if the `ConfigSource` reads the string `"RED"`, the value of `c
 
 Note that the `enum_cast` function is designed to read the *name* of an enum member, not its value (`1`, `2` or `3` in the example above)
 
-### Casting to a `list` with `list_cast`
-If the source contains a list of items, list_cast will parse them as a python list, optionally applying a 
+### Casting to a `tuple` with `tuple_cast`
+If the source contains a list of items, `tuple_cast` will parse them as a python tuple, optionally applying a 
 base_cast function to each element. 
 The default behavior is to call strip() on each element and ignore trailing delimiters.
 
@@ -511,28 +511,28 @@ nums = 1, 2, 3, 4,
 Then you could use
 
 ```python
-nums = key(cast=list_cast())
+nums = key(cast=tuple_cast())
 ```
-to read the string input and cast it to `["1", "2", "3", "4"]`
+to read the string input and cast it to `("1", "2", "3", "4")`
 
 ```python
-key(cast=list_cast(base_cast=int))
+key(cast=tuple_cast(base_cast=int))
 ```
-Would cast the input to `[1, 2, 3, 4]`
+Would cast the input to `(1, 2, 3, 4)`
 
 ```python
-key(cast=list_cast(ignore_trailing_delimiter=False))
+key(cast=tuple_cast(ignore_trailing_delimiter=False))
 ```
-Would cast the input to `["1", "2", "3", "4", ""]`
+Would cast the input to `("1", "2", "3", "4", "")`
 
 ```python
-key(cast=list_cast(strip=False))
+key(cast=tuple_cast(strip=False))
 ```
-Would cast the input to `["1", " 2", " 3", " 4"]`
+Would cast the input to `("1", " 2", " 3", " 4")`
 
 Finally, if a delimiter other that "," is used - say the input string is `"1:2:3:4"` - that can be handled like
 ```python
-key(cast=list_cast(delimiter=":"))
+key(cast=tuple_cast(delimiter=":"))
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -498,6 +498,43 @@ In this example, if the `ConfigSource` reads the string `"RED"`, the value of `c
 
 Note that the `enum_cast` function is designed to read the *name* of an enum member, not its value (`1`, `2` or `3` in the example above)
 
+### Casting to a `list` with `list_cast`
+If the source contains a list of items, list_cast will parse them as a python list, optionally applying a 
+base_cast function to each element. 
+The default behavior is to call strip() on each element and ignore trailing delimiters.
+
+For example, given the input
+```ini
+nums = 1, 2, 3, 4,
+```
+
+Then you could use
+
+```python
+nums = key(cast=list_cast())
+```
+to read the string input and cast it to `["1", "2", "3", "4"]`
+
+```python
+key(cast=list_cast(base_cast=int))
+```
+Would cast the input to `[1, 2, 3, 4]`
+
+```python
+key(cast=list_cast(ignore_trailing_delimiter=False))
+```
+Would cast the input to `["1", "2", "3", "4", ""]`
+
+```python
+key(cast=list_cast(strip=False))
+```
+Would cast the input to `["1", " 2", " 3", " 4"]`
+
+Finally, if a delimiter other that "," is used - say the input string is `"1:2:3:4"` - that can be handled like
+```python
+key(cast=list_cast(delimiter=":"))
+```
+
 ## Contributing
 Ideas for new features and pull requests are welcome. PRs must come with tests included. This was developed using Python 3.7 but Travis tests run with all versions 3.6-3.9 too.
 

--- a/test/test_casts.py
+++ b/test/test_casts.py
@@ -37,6 +37,7 @@ def test_invalid_enum_cast():
         ),
         ("a, b, c, d,", dict(), ["a", "b", "c", "d"]),
         ("a, b, c, d,", dict(strip=False), ["a", " b", " c", " d"]),
+        ("", dict(), []),
         ("", dict(base_cast=int), []),
     ],
 )

--- a/test/test_casts.py
+++ b/test/test_casts.py
@@ -10,12 +10,12 @@ class ExampleEnum(Enum):
     BLUE = 3
 
 
-def test_valid_enum_cast():
+def test_valid_enum_cast() -> None:
     getter = enum_cast(ExampleEnum)
     assert getter("BLUE") == ExampleEnum.BLUE
 
 
-def test_invalid_enum_cast():
+def test_invalid_enum_cast() -> None:
     getter = enum_cast(ExampleEnum)
     with pytest.raises(KeyError):
         getter("PURPLE")
@@ -42,6 +42,6 @@ def test_invalid_enum_cast():
         ("", dict(ignore_trailing_delimiter=False), tuple()),
     ],
 )
-def test_tuple_cast(prop_val: str, args: Dict[str, Any], expected_value: Tuple[Any]):
+def test_tuple_cast(prop_val: str, args: Dict[str, Any], expected_value: Tuple[Any]) -> None:
     getter = tuple_cast(**args)
     assert getter(prop_val) == expected_value

--- a/test/test_casts.py
+++ b/test/test_casts.py
@@ -1,7 +1,7 @@
 import pytest
 
 from enum import Enum
-from typedconfig.casts import enum_cast
+from typedconfig.casts import enum_cast, list_cast
 
 
 class ExampleEnum(Enum):
@@ -19,3 +19,27 @@ def test_invalid_enum_cast():
     getter = enum_cast(ExampleEnum)
     with pytest.raises(KeyError):
         getter("PURPLE")
+
+
+@pytest.mark.parametrize(
+    "prop_val, args, expected_value",
+    [
+        ("a,b,c,d", dict(), ["a", "b", "c", "d"]),
+        ("1, 2,  3,  4 ", dict(base_cast=int), [1, 2, 3, 4]),
+        ("a,b,c,d,", dict(), ["a", "b", "c", "d"]),
+        ("a,b,c,d,", dict(ignore_trailing_delimiter=False), ["a", "b", "c", "d", ""]),
+        ("a+b+c+d", dict(delimiter="+"), ["a", "b", "c", "d"]),
+        ("a//b//c//d//", dict(delimiter="//"), ["a", "b", "c", "d"]),
+        (
+            "RED, BLUE, GREEN",
+            dict(base_cast=enum_cast(ExampleEnum)),
+            [ExampleEnum.RED, ExampleEnum.BLUE, ExampleEnum.GREEN],
+        ),
+        ("a, b, c, d,", dict(), ["a", "b", "c", "d"]),
+        ("a, b, c, d,", dict(strip=False), ["a", " b", " c", " d"]),
+        ("", dict(base_cast=int), []),
+    ],
+)
+def test_list_cast(prop_val, args, expected_value):
+    getter = list_cast(**args)
+    assert getter(prop_val) == expected_value

--- a/test/test_casts.py
+++ b/test/test_casts.py
@@ -1,7 +1,7 @@
 import pytest
-
 from enum import Enum
-from typedconfig.casts import enum_cast, list_cast
+from typing import Dict, Tuple, Any
+from typedconfig.casts import enum_cast, tuple_cast
 
 
 class ExampleEnum(Enum):
@@ -24,23 +24,24 @@ def test_invalid_enum_cast():
 @pytest.mark.parametrize(
     "prop_val, args, expected_value",
     [
-        ("a,b,c,d", dict(), ["a", "b", "c", "d"]),
-        ("1, 2,  3,  4 ", dict(base_cast=int), [1, 2, 3, 4]),
-        ("a,b,c,d,", dict(), ["a", "b", "c", "d"]),
-        ("a,b,c,d,", dict(ignore_trailing_delimiter=False), ["a", "b", "c", "d", ""]),
-        ("a+b+c+d", dict(delimiter="+"), ["a", "b", "c", "d"]),
-        ("a//b//c//d//", dict(delimiter="//"), ["a", "b", "c", "d"]),
+        ("a,b,c,d", dict(), ("a", "b", "c", "d")),
+        ("1, 2,  3,  4 ", dict(base_cast=int), (1, 2, 3, 4)),
+        ("a,b,c,d,", dict(), ("a", "b", "c", "d")),
+        ("a,b,c,d,", dict(ignore_trailing_delimiter=False), ("a", "b", "c", "d", "")),
+        ("a+b+c+d", dict(delimiter="+"), ("a", "b", "c", "d")),
+        ("a//b//c//d//", dict(delimiter="//"), ("a", "b", "c", "d")),
         (
             "RED, BLUE, GREEN",
             dict(base_cast=enum_cast(ExampleEnum)),
-            [ExampleEnum.RED, ExampleEnum.BLUE, ExampleEnum.GREEN],
+            (ExampleEnum.RED, ExampleEnum.BLUE, ExampleEnum.GREEN),
         ),
-        ("a, b, c, d,", dict(), ["a", "b", "c", "d"]),
-        ("a, b, c, d,", dict(strip=False), ["a", " b", " c", " d"]),
-        ("", dict(), []),
-        ("", dict(base_cast=int), []),
+        ("a, b, c, d,", dict(), ("a", "b", "c", "d")),
+        ("a, b, c, d,", dict(strip=False), ("a", " b", " c", " d")),
+        ("", dict(), tuple()),
+        ("", dict(base_cast=int), tuple()),
+        ("", dict(ignore_trailing_delimiter=False), tuple()),
     ],
 )
-def test_list_cast(prop_val, args, expected_value):
-    getter = list_cast(**args)
+def test_tuple_cast(prop_val: str, args: dict[str, Any], expected_value: tuple[Any]):
+    getter = tuple_cast(**args)
     assert getter(prop_val) == expected_value

--- a/test/test_casts.py
+++ b/test/test_casts.py
@@ -42,6 +42,6 @@ def test_invalid_enum_cast():
         ("", dict(ignore_trailing_delimiter=False), tuple()),
     ],
 )
-def test_tuple_cast(prop_val: str, args: dict[str, Any], expected_value: tuple[Any]):
+def test_tuple_cast(prop_val: str, args: Dict[str, Any], expected_value: Tuple[Any]):
     getter = tuple_cast(**args)
     assert getter(prop_val) == expected_value

--- a/typedconfig/__version__.py
+++ b/typedconfig/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 3, 1)
+VERSION = (1, 3, 2)
 
 __version__ = ".".join(map(str, VERSION))

--- a/typedconfig/casts.py
+++ b/typedconfig/casts.py
@@ -14,7 +14,7 @@ def enum_cast(enum_type: Type[TEnum]) -> Callable[[str], TEnum]:
     ----------
     enum_type
        The EnumType that the string input should be cast to
-       
+
     Returns
     -------
     Cast method that can be used with the key() function
@@ -30,12 +30,7 @@ def enum_cast(enum_type: Type[TEnum]) -> Callable[[str], TEnum]:
 
 
 @overload
-def list_cast(
-    base_cast=None,
-    delimiter=...,
-    ignore_trailing_delimiter=...,
-    strip=...
-) -> Callable[[str], List[str]]:
+def list_cast(base_cast=None, delimiter=..., ignore_trailing_delimiter=..., strip=...) -> Callable[[str], List[str]]:
     ...
 
 
@@ -61,19 +56,19 @@ def list_cast(
 
     Parameters
     ----------
-    base_cast: 
+    base_cast:
         function to be applied to each member of the parsed list before returning. If base_cast is None, the
         cast function will return a list of strings
-    delimiter: 
+    delimiter:
         delimiter to use to separate elements when parsing the input. Default is a comma.
-    ignore_trailing_delimiter: 
-        How to interpret a trailing delimiter, as in "one,two,three,". 
+    ignore_trailing_delimiter:
+        How to interpret a trailing delimiter, as in "one,two,three,".
         If True (the default) the funal comma will be dropped
         If False, the list would end with a single empty string
     strip:
-        Whether to call strip() on each element of the parsed strings. 
+        Whether to call strip() on each element of the parsed strings.
         If True (the default) an input like "a, b, c" will be cast as ["a", "b", "c"]
-        If False an input like "a, b, c" will be cast as ["a", "b ", "c "], with no 
+        If False an input like "a, b, c" will be cast as ["a", "b ", "c "], with no
         extraneous whitespace removed
 
     Returns

--- a/typedconfig/casts.py
+++ b/typedconfig/casts.py
@@ -1,14 +1,104 @@
 from enum import Enum
-from typing import TypeVar, Callable, Type
+from typing import Callable, List, Optional, Type, TypeVar, Union, overload
 
+T = TypeVar("T")
 TEnum = TypeVar("TEnum", bound="Enum")
 
 
 def enum_cast(enum_type: Type[TEnum]) -> Callable[[str], TEnum]:
+    """
+    A cast function that translates a string input into a member of named Enum
+    Throws a KeyError of the string is not in the given Enum
+
+    Parameters
+    ----------
+    enum_type
+       The EnumType that the string input should be cast to
+       
+    Returns
+    -------
+    Cast method that can be used with the key() function
+    """
+
     def getter(name: str) -> TEnum:
         try:
             return enum_type[name]
         except KeyError:
             raise KeyError(f"{name} is not a member of {enum_type}")
+
+    return getter
+
+
+@overload
+def list_cast(
+    base_cast=None,
+    delimiter=...,
+    ignore_trailing_delimiter=...,
+    strip=...
+) -> Callable[[str], List[str]]:
+    ...
+
+
+@overload
+def list_cast(
+    base_cast=Callable[[str], T],
+    delimiter=...,
+    ignore_trailing_delimiter=...,
+    strip=...,
+) -> Callable[[str], List[T]]:
+    ...
+
+
+def list_cast(
+    base_cast: Optional[Callable[[str], T]] = None,
+    delimiter: str = ",",
+    ignore_trailing_delimiter: bool = True,
+    strip: bool = True,
+) -> Callable[[str], Union[List[T], List[str]]]:
+    """
+    A cast function that creates a list based on the given base_cast function.
+    If no base_cast method is provided, returns a list of str.
+
+    Parameters
+    ----------
+    base_cast: 
+        function to be applied to each member of the parsed list before returning. If base_cast is None, the
+        cast function will return a list of strings
+    delimiter: 
+        delimiter to use to separate elements when parsing the input. Default is a comma.
+    ignore_trailing_delimiter: 
+        How to interpret a trailing delimiter, as in "one,two,three,". 
+        If True (the default) the funal comma will be dropped
+        If False, the list would end with a single empty string
+    strip:
+        Whether to call strip() on each element of the parsed strings. 
+        If True (the default) an input like "a, b, c" will be cast as ["a", "b", "c"]
+        If False an input like "a, b, c" will be cast as ["a", "b ", "c "], with no 
+        extraneous whitespace removed
+
+    Returns
+    -------
+    Cast method that can be used with the key() function
+    """
+
+    def getter(s: str) -> Union[List[T], List[str]]:
+        # if the string is empty string, allways return empty list
+        if len(s) == 0:
+            return []
+        str_list = s.split(delimiter)
+
+        # remove whitespace if the strip arg is True
+        if strip:
+            str_list = [s.strip() for s in str_list]
+
+        # remove the final element if it is empty and we should ignore trailing delimiters
+        if ignore_trailing_delimiter and len(str_list[-1]) == 0:
+            str_list = str_list[:-1]
+
+        # no base_cast means just a list of str
+        if base_cast is None:
+            return str_list
+
+        return [base_cast(s) for s in str_list]
 
     return getter

--- a/typedconfig/casts.py
+++ b/typedconfig/casts.py
@@ -81,7 +81,7 @@ def tuple_cast(
     Cast method that can be used with the key() function
     """
 
-    def getter(s: str) -> Union[tuple[T, ...], tuple[str, ...]]:
+    def getter(s: str) -> Union[Tuple[T, ...], Tuple[str, ...]]:
         # If the string is empty string, allways return empty list
         # The empty list needs an explicit type to make mypy happy
         if len(s) == 0:

--- a/typedconfig/casts.py
+++ b/typedconfig/casts.py
@@ -30,16 +30,21 @@ def enum_cast(enum_type: Type[TEnum]) -> Callable[[str], TEnum]:
 
 
 @overload
-def list_cast(base_cast=None, delimiter=..., ignore_trailing_delimiter=..., strip=...) -> Callable[[str], List[str]]:
+def list_cast(
+    base_cast: None = ...,
+    delimiter: str = ...,
+    ignore_trailing_delimiter: bool = ...,
+    strip: bool = ...,
+) -> Callable[[str], List[str]]:
     ...
 
 
 @overload
 def list_cast(
-    base_cast=Callable[[str], T],
-    delimiter=...,
-    ignore_trailing_delimiter=...,
-    strip=...,
+    base_cast: Optional[Callable[[str], T]] = ...,
+    delimiter: str = ...,
+    ignore_trailing_delimiter: bool = ...,
+    strip: bool = ...,
 ) -> Callable[[str], List[T]]:
     ...
 
@@ -77,9 +82,16 @@ def list_cast(
     """
 
     def getter(s: str) -> Union[List[T], List[str]]:
-        # if the string is empty string, allways return empty list
+        # If the string is empty string, allways return empty list
+        # The empty list needs an explicit type to make mypy happy
         if len(s) == 0:
-            return []
+            if base_cast is None:
+                str_list: List[str] = []
+                return str_list
+            else:
+                t_list: List[T] = []
+                return t_list
+
         str_list = s.split(delimiter)
 
         # remove whitespace if the strip arg is True

--- a/typedconfig/casts.py
+++ b/typedconfig/casts.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Callable, List, Optional, Type, TypeVar, Union, overload
+from typing import Callable, Optional, Type, TypeVar, Tuple, Union, overload
 
 T = TypeVar("T")
 TEnum = TypeVar("TEnum", bound="Enum")
@@ -30,31 +30,31 @@ def enum_cast(enum_type: Type[TEnum]) -> Callable[[str], TEnum]:
 
 
 @overload
-def list_cast(
-    base_cast: None = ...,
+def tuple_cast(
+    base_cast: None = None,
     delimiter: str = ...,
     ignore_trailing_delimiter: bool = ...,
     strip: bool = ...,
-) -> Callable[[str], List[str]]:
+) -> Callable[[str], Tuple[str, ...]]:
     ...
 
 
 @overload
-def list_cast(
-    base_cast: Optional[Callable[[str], T]] = ...,
+def tuple_cast(
+    base_cast: Callable[[str], T],
     delimiter: str = ...,
     ignore_trailing_delimiter: bool = ...,
     strip: bool = ...,
-) -> Callable[[str], List[T]]:
+) -> Callable[[str], Tuple[T, ...]]:
     ...
 
 
-def list_cast(
+def tuple_cast(
     base_cast: Optional[Callable[[str], T]] = None,
     delimiter: str = ",",
     ignore_trailing_delimiter: bool = True,
     strip: bool = True,
-) -> Callable[[str], Union[List[T], List[str]]]:
+) -> Callable[[str], Union[Tuple[T, ...], Tuple[str, ...]]]:
     """
     A cast function that creates a list based on the given base_cast function.
     If no base_cast method is provided, returns a list of str.
@@ -81,16 +81,16 @@ def list_cast(
     Cast method that can be used with the key() function
     """
 
-    def getter(s: str) -> Union[List[T], List[str]]:
+    def getter(s: str) -> Union[tuple[T, ...], tuple[str, ...]]:
         # If the string is empty string, allways return empty list
         # The empty list needs an explicit type to make mypy happy
         if len(s) == 0:
             if base_cast is None:
-                str_list: List[str] = []
-                return str_list
+                str_tuple: Tuple[str, ...] = tuple()
+                return str_tuple
             else:
-                t_list: List[T] = []
-                return t_list
+                t_tuple: Tuple[T, ...] = tuple()
+                return t_tuple
 
         str_list = s.split(delimiter)
 
@@ -104,8 +104,8 @@ def list_cast(
 
         # no base_cast means just a list of str
         if base_cast is None:
-            return str_list
+            return tuple(str_list)
 
-        return [base_cast(s) for s in str_list]
+        return tuple([base_cast(s) for s in str_list])
 
     return getter

--- a/typedconfig/casts.py
+++ b/typedconfig/casts.py
@@ -100,12 +100,12 @@ def tuple_cast(
 
         # remove the final element if it is empty and we should ignore trailing delimiters
         if ignore_trailing_delimiter and len(str_list[-1]) == 0:
-            str_list = str_list[:-1]
+            str_list.pop()
 
         # no base_cast means just a list of str
         if base_cast is None:
             return tuple(str_list)
 
-        return tuple([base_cast(s) for s in str_list])
+        return tuple(base_cast(s) for s in str_list)
 
     return getter


### PR DESCRIPTION
This should be a useful addition, hopefully covering a reasonable set of use cases.  I added tests and documentation.

One open question might be returning collection types other that list. For example, would tuple_cast be useful?

Maybe not needed since 
key(cast=tuple(list_cast(...) ) )
is easy enough. 